### PR TITLE
Add support for nested modules

### DIFF
--- a/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
+++ b/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
@@ -40,6 +40,10 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime do
   def filter_out_ops([], acc), do: acc
   def filter_out_ops(ast, _acc), do: ast
 
+  defp find_environment_vars_getter({:defmodule, _, _} = ast, issues, issue_meta) do
+    traverse(ast, issues, issue_meta)
+  end
+
   defp find_environment_vars_getter(ast, issues, issue_meta) do
     {ast, Credo.Code.prewalk(ast, &traverse_inside_defmodule(&1, &2, issue_meta)) ++ issues}
   end

--- a/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
+++ b/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
@@ -45,6 +45,22 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTimeTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report expected code when it is in a nested module" do
+    """
+    defmodule CredoSampleModule do
+      defmodule Foo do
+        defmodule Bar do
+          def some_foobar do
+            Application.get_env(:param1, :param2)
+          end
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report expected code when there are get env vars inside def" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
Hi! I added support for nested modules because the check was finding issues in the following code : 

```elixir
defmodule CredoSampleModule do
  defmodule Foo do
    defmodule Bar do
      def some_foobar do
        Application.get_env(:param1, :param2)
      end
    end
  end
end
```

while this code wasn’t raising an issue (as it should’nt) :

```elixir
defmodule CredoSampleModule.Foo.Bar do
  def some_foobar do
    Application.get_env(:param1, :param2)
  end
end
```

Not anymore! 😁 