### PR TITLE
Add support for nested modules with siblings

### DIFF
--- a/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
+++ b/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
@@ -48,6 +48,10 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime do
     {ast, Credo.Code.prewalk(ast, &traverse_inside_defmodule(&1, &2, issue_meta)) ++ issues}
   end
 
+  defp traverse_inside_defmodule({:defmodule, _, _} = ast, issues, issue_meta) do
+    traverse(ast, issues, issue_meta)
+  end
+
   for {ops, fun} <- @get_env_ops_fun do
     defp traverse_inside_defmodule(
            {:., meta, [{:__aliases__, _meta, [unquote(ops)]}, unquote(fun)]} = ast,

--- a/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
+++ b/lib/credo_envvar/check/warning/environment_variables_at_compile_time.ex
@@ -16,7 +16,9 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTime do
   def run(source_file, params \\ []) do
     issue_meta = IssueMeta.for(source_file, params)
 
-    Credo.Code.prewalk(source_file, &traverse(&1, &2, issue_meta))
+    source_file
+    |> Credo.Code.prewalk(&traverse(&1, &2, issue_meta))
+    |> Enum.uniq_by(&{&1.line_no, &1.column, &1.scope})
   end
 
   defp traverse({:defmodule, _, _} = ast, issues, issue_meta) do

--- a/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
+++ b/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
@@ -61,6 +61,26 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTimeTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should NOT report expected code when it is in a nested module with siblings" do
+    """
+    defmodule CredoSampleModule do
+      defmodule Foo do
+        def some_foobar do
+          Application.get_env(:param1, :param2)
+        end
+      end
+
+      defmodule Bar do
+        def some_foobar do
+          Application.get_env(:param1, :param2)
+        end
+      end
+    end
+    """
+    |> to_source_file
+    |> refute_issues(@described_check)
+  end
+
   test "it should NOT report expected code when there are get env vars inside def" do
     """
     defmodule CredoSampleModule do

--- a/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
+++ b/test/credo_envvar/check/warning/environment_variables_at_compile_time_test.exs
@@ -81,6 +81,24 @@ defmodule CredoEnvvar.Check.Warning.EnvironmentVariablesAtCompileTimeTest do
     |> refute_issues(@described_check)
   end
 
+  test "it should report expected code when assigns env var to module attribute with Application.get_env in nested siblings module" do
+    """
+    defmodule CredoSampleModule do
+      defmodule NestedModule1 do
+        def foo_bar do
+          Application.get_env(:param1, :param2)
+        end
+      end
+
+      defmodule NestedModule2 do
+        @compile_param Application.get_env(:param1, :param2)
+      end
+    end
+    """
+    |> to_source_file
+    |> assert_issue(@described_check)
+  end
+
   test "it should NOT report expected code when there are get env vars inside def" do
     """
     defmodule CredoSampleModule do


### PR DESCRIPTION
My previous code (#3) only worked when a nested module didn’t have any siblings.